### PR TITLE
CSD-460 feat: Integrating database Schema file

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,23 @@ Note: This turns off the virtual environment and returns you to your system Pyth
 
 ---
 
+## Database Setup (MySQL)
+
+To **set up the schema locally**, follow these steps:
+
+1. Make sure MySQL is installed and running on your machine.  
+
+2. From the project root directory (`Moffat_Bay`), run the following command in your terminal (NOTE this will DROP the old moffat_bay database if it exists.):  
+``mysql -u root -p < db/schema.sql``  
+
+To **populate the database**, follow these steps (**Not yet included in this repo, WIP**):
+
+1. From the project root directory (`Moffat_Bay`), run the following command in your terminal:
+``mysql -u root -p moffat_bay < db/data.sql``
+
+
+---
+
 ## Contributors
 | Role              | Name           |
 |-------------------|----------------|

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,0 +1,102 @@
+-- Drop the database if it already exists
+DROP DATABASE IF EXISTS moffat_bay;
+
+-- Create the database
+CREATE DATABASE moffat_bay;
+
+-- Use this database
+USE moffat_bay;
+
+-- --------------------------------------------------------
+-- Table structure for table `customer`
+-- --------------------------------------------------------
+CREATE TABLE `customer` (
+  `CustomerID` int(11) NOT NULL AUTO_INCREMENT,
+  `FirstName` varchar(50) NOT NULL,
+  `LastName` varchar(50) NOT NULL,
+  `Email` varchar(100) NOT NULL UNIQUE,
+  `Phone` varchar(20) DEFAULT NULL,
+  `PasswordHash` varchar(255) NOT NULL,
+  `RegistrationDate` datetime DEFAULT current_timestamp(),
+  PRIMARY KEY (`CustomerID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- --------------------------------------------------------
+-- Table structure for table `roomtype`
+-- --------------------------------------------------------
+CREATE TABLE `roomtype` (
+  `RoomTypeID` int(11) NOT NULL AUTO_INCREMENT,
+  `TypeName` varchar(50) NOT NULL,
+  `BedConfiguration` varchar(50) DEFAULT NULL,
+  `PricePerNight` decimal(8,2) NOT NULL,
+  PRIMARY KEY (`RoomTypeID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- --------------------------------------------------------
+-- Table structure for table `amenity`
+-- --------------------------------------------------------
+CREATE TABLE `amenity` (
+  `AmenityID` int(11) NOT NULL AUTO_INCREMENT,
+  `Name` varchar(50) NOT NULL,
+  `Description` text DEFAULT NULL,
+  PRIMARY KEY (`AmenityID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- --------------------------------------------------------
+-- Table structure for table `room`
+-- --------------------------------------------------------
+CREATE TABLE `room` (
+  `RoomID` int(11) NOT NULL AUTO_INCREMENT,
+  `RoomNumber` varchar(10) NOT NULL UNIQUE,
+  `RoomTypeID` int(11) NOT NULL,
+  `HandicapAccessible` tinyint(1) DEFAULT 0,
+  `Description` text DEFAULT NULL,
+  PRIMARY KEY (`RoomID`),
+  KEY `RoomTypeID` (`RoomTypeID`),
+  CONSTRAINT `room_ibfk_1` FOREIGN KEY (`RoomTypeID`) REFERENCES `roomtype` (`RoomTypeID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- --------------------------------------------------------
+-- Table structure for table `roomamenity`
+-- --------------------------------------------------------
+CREATE TABLE `roomamenity` (
+  `RoomID` int(11) NOT NULL,
+  `AmenityID` int(11) NOT NULL,
+  PRIMARY KEY (`RoomID`,`AmenityID`),
+  KEY `AmenityID` (`AmenityID`),
+  CONSTRAINT `roomamenity_ibfk_1` FOREIGN KEY (`RoomID`) REFERENCES `room` (`RoomID`),
+  CONSTRAINT `roomamenity_ibfk_2` FOREIGN KEY (`AmenityID`) REFERENCES `amenity` (`AmenityID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- --------------------------------------------------------
+-- Table structure for table `reservation`
+-- --------------------------------------------------------
+CREATE TABLE `reservation` (
+  `ReservationID` int(11) NOT NULL AUTO_INCREMENT,
+  `CustomerID` int(11) NOT NULL,
+  `RoomID` int(11) NOT NULL,
+  `CheckInDate` date NOT NULL,
+  `CheckOutDate` date NOT NULL,
+  `NumberOfGuests` int(11) NOT NULL,
+  `ReservationStatus` enum('Pending','Confirmed','Cancelled') DEFAULT 'Pending',
+  `DateReserved` datetime DEFAULT current_timestamp(),
+  PRIMARY KEY (`ReservationID`),
+  KEY `CustomerID` (`CustomerID`),
+  KEY `RoomID` (`RoomID`),
+  CONSTRAINT `reservation_ibfk_1` FOREIGN KEY (`CustomerID`) REFERENCES `customer` (`CustomerID`),
+  CONSTRAINT `reservation_ibfk_2` FOREIGN KEY (`RoomID`) REFERENCES `room` (`RoomID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- --------------------------------------------------------
+-- Table structure for table `auditlog`
+-- --------------------------------------------------------
+CREATE TABLE `auditlog` (
+  `AuditLogID` int(11) NOT NULL AUTO_INCREMENT,
+  `CustomerID` int(11) DEFAULT NULL,
+  `Action` varchar(50) NOT NULL,
+  `Description` text DEFAULT NULL,
+  `Timestamp` datetime DEFAULT current_timestamp(),
+  PRIMARY KEY (`AuditLogID`),
+  KEY `CustomerID` (`CustomerID`),
+  CONSTRAINT `auditlog_ibfk_1` FOREIGN KEY (`CustomerID`) REFERENCES `customer` (`CustomerID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;


### PR DESCRIPTION
### **Summary**
This PR adds the initial MySQL schema for the Moffat Bay project. The schema defines all required tables, relationships, and constraints to support customer registration, room management, reservations, and audit logging.

### **Changes Made**
	•	Added db/schema.sql containing table structures for customer, reservation, room, roomtype, amenity, roomamenity, and auditlog.
	•	Included primary keys, unique constraints, and foreign key relationships.
	•	Added DROP DATABASE IF EXISTS and CREATE DATABASE statements to simplify setup for teammates.
	•	Updated project documentation (README file) to explain how to load the schema into MySQL and populate database.